### PR TITLE
feat: Support directory paths as well (#5)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,4 +30,4 @@ jobs:
     - name: Self Report
       # Generates a report based on the logged data from verifying itself.
       # This is both a guard against unstable verification and a smoke test of the tool itself.
-      run: dotnet run --project src -- summarize-csv-results --max-resource-count 1000000 src/TestResults/*.csv test/TestResults/*.csv
+      run: dotnet run --project src -- summarize-csv-results --max-resource-count 1000000 .

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ were created by passing `/verificationLogger:csv` when invoking the `dafny` comm
 is set unrealistically low here, just to demonstrate the behavior when violated.
 
 ```
-> dafny-reportgenerator summarize-csv-results --max-resource-count 500000 src/TestResults/*.csv test/TestResults/*.csv
+> dafny-reportgenerator summarize-csv-results --max-resource-count 500000 .
 All results: 
 
 Impl$$Main.__default.ParseCommandLineOptions(Passed) - Duration = 00:00:00.1940000, Resource Count = 581969

--- a/src/Externs.dfy
+++ b/src/Externs.dfy
@@ -10,6 +10,7 @@ module Externs {
   method {:extern} GetCommandLineArgs() returns (args: seq<string>)
   method {:extern} SetExitCode(exitCode: uint8)
 
+  method {:extern} FindAllCSVTestResultFiles(path: string) returns (lines: Result<seq<string>, string>)
   method {:extern} ReadAllFileLines(path: string) returns (lines: Result<seq<string>, string>)
 
   function method {:extern} ParseNat(s: string): Result<nat, string>

--- a/src/dafny-reportgenerator.csproj
+++ b/src/dafny-reportgenerator.csproj
@@ -5,10 +5,17 @@
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>dafny_reportgenerator</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
+
+    <PackageVersion>1.1.0</PackageVersion>
+
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>dafny-reportgenerator</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="dafny.msbuild" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The updated help text says it all:

file_paths                 CSV files produced from Dafny's /verificationLogger:csv feature.
                           Directory paths are also accepted, in which case all CSV files under all
                           "TestResults" descendant directories are included.

Also adds missing project file properties for publishing to nuget.